### PR TITLE
added an origin of error to the catch statement

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -95,7 +95,7 @@ Promise.prototype.caught = Promise.prototype["catch"] = function (fn) {
             if (util.isObject(item)) {
                 catchInstances[j++] = item;
             } else {
-                return apiRejection(OBJECT_ERROR + util.classString(item));
+                return apiRejection(OBJECT_ERROR + "A catch statement predicate " + util.classString(item));
             }
         }
         catchInstances.length = j;


### PR DESCRIPTION
I spent an hour and a half trying to debug by promise-based api today. I couldn't figure out why I was getting a type error until I realized I was passing undefined as one of my error predicates. If the error message was more descriptive, It would has greatly reduced my debug time. Let me know if this prefix is happening in the right spot.
